### PR TITLE
MDI-594 | fix: sanitize internal errors in callback reason field

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -39,7 +39,22 @@ Le operazioni MySQL (Update, Ready, Create) sono eseguite in transazione:
 ### Email Failed
 Quando l'invio SMTP fallisce:
 - Stato: `FAILED`
-- Reason: Messaggio di errore originale dall'SMTP client
+- Il sistema notifica il chiamante tramite la FailedCallbackPipeline (HTTP POST con code: "DISPATCH-ERROR")
+- Stato finale: `FAILED-ACKNOWLEDGED`
+
+### Email Invalid
+Quando la validazione del payload fallisce durante l'intake:
+- Stato: `INVALID`
+- Il sistema notifica il chiamante tramite la InvalidCallbackPipeline (HTTP POST con code: "DISPATCH-ERROR")
+- Stato finale: `INVALID-ACKNOWLEDGED`
+
+### Sanitizzazione del Reason nelle Callback
+Il campo `reason` nel database conserva sempre l'errore originale completo per il debugging. La sanitizzazione avviene esclusivamente al momento dell'invio della callback HTTP, nella `CallbackPipeline`:
+
+- **Errori SMTP** (reason che inizia con codice a 3 cifre, es. "552 5.3.4 Message too long"): il messaggio del server viene preservato, in quanto informativo per il cliente
+- **Errori interni** (caricamento payload, costruzione messaggio, connessione, autenticazione, TLS, validazione): viene inviato un messaggio generico ("Errore interno di elaborazione")
+
+Il database mantiene sempre l'errore originale completo per il debugging interno.
 
 ### SMTP Throttling (454)
 Quando l'invio SMTP fallisce con codice `454` (throttling):

--- a/internal/pipeline/callback.go
+++ b/internal/pipeline/callback.go
@@ -8,11 +8,16 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 
 	"mailculator-processor/internal/outbox"
 )
+
+const internalErrorReason = "Errore interno di elaborazione"
+
+var smtpErrorPattern = regexp.MustCompile(`^\d{3} `)
 
 type CallbackConfig struct {
 	MaxRetries    int
@@ -61,7 +66,7 @@ func (p *CallbackPipeline) Process(ctx context.Context) {
 				reason = "Consegnato al server di posta"
 			} else {
 				statusCode = "DISPATCH-ERROR"
-				reason = email.Reason
+				reason = sanitizeReason(email.Reason)
 			}
 
 			payload := map[string]any{
@@ -151,6 +156,16 @@ func (p *CallbackPipeline) Process(ctx context.Context) {
 	}
 
 	wg.Wait()
+}
+
+// sanitizeReason returns the original reason if it looks like an SMTP server
+// response (e.g. "552 5.3.4 Message too long"), or a generic message for
+// internal errors that should not be exposed to external clients.
+func sanitizeReason(reason string) string {
+	if smtpErrorPattern.MatchString(reason) {
+		return reason
+	}
+	return internalErrorReason
 }
 
 func NewSentCallbackPipeline(ob outboxService, cfg CallbackConfig) *CallbackPipeline {

--- a/internal/pipeline/callback_test.go
+++ b/internal/pipeline/callback_test.go
@@ -4,15 +4,18 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"mailculator-processor/internal/outbox"
-	"mailculator-processor/internal/testutils/mocks"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"mailculator-processor/internal/outbox"
+	"mailculator-processor/internal/testutils/mocks"
 )
 
 type testServer struct {
@@ -61,6 +64,104 @@ func TestSuccessCallbackPipeline(t *testing.T) {
 			strings.TrimSpace(buf.String()),
 		)
 	}
+}
+
+func TestSanitizeReason_SMTPError_PreservesOriginal(t *testing.T) {
+	assert.Equal(t, "552 5.3.4 Message too long", sanitizeReason("552 5.3.4 Message too long"))
+	assert.Equal(t, "550 5.1.1 User unknown", sanitizeReason("550 5.1.1 User unknown"))
+	assert.Equal(t, "421 Service not available", sanitizeReason("421 Service not available"))
+}
+
+func TestSanitizeReason_InternalError_ReturnsGeneric(t *testing.T) {
+	assert.Equal(t, internalErrorReason, sanitizeReason("failed to read payload file /data/payloads/xyz.json: no such file or directory"))
+	assert.Equal(t, internalErrorReason, sanitizeReason("dial tcp smtp-host:587: connection refused"))
+	assert.Equal(t, internalErrorReason, sanitizeReason("failed to read attachment: open /data/attachments/file.pdf: permission denied"))
+	assert.Equal(t, internalErrorReason, sanitizeReason("failed to unmarshal payload: invalid character"))
+	assert.Equal(t, internalErrorReason, sanitizeReason("payload validation failed: Key: 'Payload.To' Error:Field validation"))
+	assert.Equal(t, internalErrorReason, sanitizeReason(""))
+}
+
+func TestInvalidCallbackPipeline_SanitizesInternalReason(t *testing.T) {
+	outboxServiceMock := mocks.NewOutboxMock(mocks.Email(outbox.Email{
+		Id:     "1",
+		Status: outbox.StatusInvalid,
+		Reason: "payload validation failed: Key: 'Payload.To' Error:Field validation for 'To' failed",
+	}))
+	callbackConfig := CallbackConfig{RetryInterval: 2, MaxRetries: 3}
+
+	var receivedBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bodyBytes, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	callbackConfig.Url = ts.URL
+	buf, logger := mocks.NewLoggerMock()
+	callback := NewInvalidCallbackPipeline(outboxServiceMock, callbackConfig)
+	callback.logger = logger
+
+	callback.Process(context.TODO())
+
+	assert.Equal(t, "DISPATCH-ERROR", receivedBody["code"])
+	assert.Equal(t, internalErrorReason, receivedBody["reason"])
+	assert.Equal(t, []any{"1"}, receivedBody["message_ids"])
+	assert.Contains(t, buf.String(), "callback successfully processed")
+}
+
+func TestFailedCallbackPipeline_PreservesSMTPReason(t *testing.T) {
+	outboxServiceMock := mocks.NewOutboxMock(mocks.Email(outbox.Email{
+		Id:     "1",
+		Status: outbox.StatusFailed,
+		Reason: "552 5.3.4 Message too long",
+	}))
+	callbackConfig := CallbackConfig{RetryInterval: 2, MaxRetries: 3}
+
+	var receivedBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bodyBytes, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	callbackConfig.Url = ts.URL
+	_, logger := mocks.NewLoggerMock()
+	callback := NewFailedCallbackPipeline(outboxServiceMock, callbackConfig)
+	callback.logger = logger
+
+	callback.Process(context.TODO())
+
+	assert.Equal(t, "DISPATCH-ERROR", receivedBody["code"])
+	assert.Equal(t, "552 5.3.4 Message too long", receivedBody["reason"])
+}
+
+func TestFailedCallbackPipeline_SanitizesInternalReason(t *testing.T) {
+	outboxServiceMock := mocks.NewOutboxMock(mocks.Email(outbox.Email{
+		Id:     "1",
+		Status: outbox.StatusFailed,
+		Reason: "dial tcp smtp-host:587: connection refused",
+	}))
+	callbackConfig := CallbackConfig{RetryInterval: 2, MaxRetries: 3}
+
+	var receivedBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bodyBytes, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	callbackConfig.Url = ts.URL
+	_, logger := mocks.NewLoggerMock()
+	callback := NewFailedCallbackPipeline(outboxServiceMock, callbackConfig)
+	callback.logger = logger
+
+	callback.Process(context.TODO())
+
+	assert.Equal(t, "DISPATCH-ERROR", receivedBody["code"])
+	assert.Equal(t, internalErrorReason, receivedBody["reason"])
 }
 
 func TestQueryCallbackError(t *testing.T) {

--- a/internal/pipeline/intake_test.go
+++ b/internal/pipeline/intake_test.go
@@ -133,6 +133,8 @@ func TestIntakeInvalidPayloadFile(t *testing.T) {
 	assert.Contains(t, buf.String(), "level=INFO msg=\"processing outbox 1\"")
 	assert.Contains(t, buf.String(), "level=ERROR msg=\"failed to validate payload")
 	assert.Contains(t, buf.String(), "failed to read payload file")
+	assert.Equal(t, outbox.StatusInvalid, outboxServiceMock.LastUpdateStatus)
+	assert.Contains(t, outboxServiceMock.LastUpdateReason, "failed to read payload file")
 }
 
 func TestIntakeInvalidJSON(t *testing.T) {
@@ -163,7 +165,6 @@ func TestIntakeInvalidJSON(t *testing.T) {
 }
 
 func TestIntakeValidationError(t *testing.T) {
-	// Invalid payload - missing required fields
 	payload := email.Payload{
 		Id:      "invalid-uuid",
 		From:    "not-an-email",
@@ -188,6 +189,8 @@ func TestIntakeValidationError(t *testing.T) {
 
 	assert.Contains(t, buf.String(), "level=ERROR msg=\"failed to validate payload")
 	assert.Contains(t, buf.String(), "payload validation failed")
+	assert.Equal(t, outbox.StatusInvalid, outboxServiceMock.LastUpdateStatus)
+	assert.Contains(t, outboxServiceMock.LastUpdateReason, "payload validation failed")
 }
 
 func TestSuccessfulIntakeWithAttachmentsAsStrings(t *testing.T) {

--- a/internal/pipeline/sender_test.go
+++ b/internal/pipeline/sender_test.go
@@ -106,22 +106,48 @@ func TestUpdateError(t *testing.T) {
 	)
 }
 
-func TestSendEmailError(t *testing.T) {
+func TestSendEmailError_InternalError_StoresFullReason(t *testing.T) {
 	payloadFile := createPayloadFile(t)
 	buf, logger := mocks.NewLoggerMock()
 	outboxServiceMock := mocks.NewOutboxMock(
 		mocks.Email(outbox.Email{Id: "1", Status: "", PayloadFilePath: payloadFile}),
 	)
-	senderServiceMock := newSenderMock(errors.New("some send error"))
+	senderServiceMock := newSenderMock(errors.New("dial tcp smtp-host:587: connection refused"))
 	sender := MainSenderPipeline{outbox: outboxServiceMock, client: senderServiceMock, attachmentsBasePath: "/base/path/", logger: logger}
 
 	sender.Process(context.TODO())
 
 	assert.Equal(t, 0, senderServiceMock.sendMethodCounter)
-	assert.Equal(t,
-		"level=INFO msg=\"processing outbox 1\"\nlevel=ERROR msg=\"failed to send, error: some send error\" outbox=1",
-		strings.TrimSpace(buf.String()),
+	assert.Equal(t, "dial tcp smtp-host:587: connection refused", outboxServiceMock.LastUpdateReason)
+	assert.Contains(t, buf.String(), "connection refused")
+}
+
+func TestSendEmailError_SMTPError_StoresFullReason(t *testing.T) {
+	payloadFile := createPayloadFile(t)
+	_, logger := mocks.NewLoggerMock()
+	outboxServiceMock := mocks.NewOutboxMock(
+		mocks.Email(outbox.Email{Id: "1", Status: "", PayloadFilePath: payloadFile}),
 	)
+	senderServiceMock := newSenderMock(&textproto.Error{Code: 552, Msg: "5.3.4 Message too long"})
+	sender := MainSenderPipeline{outbox: outboxServiceMock, client: senderServiceMock, attachmentsBasePath: "/base/path/", logger: logger}
+
+	sender.Process(context.TODO())
+
+	assert.Equal(t, "552 5.3.4 Message too long", outboxServiceMock.LastUpdateReason)
+}
+
+func TestSendEmailError_PayloadLoadError_StoresFullReason(t *testing.T) {
+	_, logger := mocks.NewLoggerMock()
+	outboxServiceMock := mocks.NewOutboxMock(
+		mocks.Email(outbox.Email{Id: "1", Status: "", PayloadFilePath: "/nonexistent/payload.json"}),
+	)
+	senderServiceMock := newSenderMock(nil)
+	sender := MainSenderPipeline{outbox: outboxServiceMock, client: senderServiceMock, attachmentsBasePath: "/base/path/", logger: logger}
+
+	sender.Process(context.TODO())
+
+	assert.Equal(t, 0, senderServiceMock.sendMethodCounter)
+	assert.Contains(t, outboxServiceMock.LastUpdateReason, "failed to read payload file")
 }
 
 func TestSendEmailThrottlingRestore(t *testing.T) {

--- a/internal/testutils/mocks/outbox.go
+++ b/internal/testutils/mocks/outbox.go
@@ -18,6 +18,8 @@ type OutboxMock struct {
 	updateFromFailsCall   int
 	email                 outbox.Email
 	lastMethod            string
+	LastUpdateStatus      string
+	LastUpdateReason      string
 }
 
 type OutboxMockOptions func(*OutboxMock)
@@ -95,6 +97,8 @@ func (m *OutboxMock) QueryStale(ctx context.Context, status string, olderThan ti
 
 func (m *OutboxMock) Update(ctx context.Context, id string, status string, errorReason string) error {
 	m.lastMethod = "update"
+	m.LastUpdateStatus = status
+	m.LastUpdateReason = errorReason
 	m.updateMethodCall++
 	if m.updateMethodCall == m.updateMethodFailsCall {
 		return m.updateMethodError


### PR DESCRIPTION
https://multidialogo.atlassian.net/browse/MDI-594